### PR TITLE
Fix song shuffle workflow path

### DIFF
--- a/.github/workflows/shuffle-songs.yml
+++ b/.github/workflows/shuffle-songs.yml
@@ -21,11 +21,11 @@ jobs:
           
       - name: Run shuffle_songs.py
         run: |
-          python shuffle_songs.py
+          python music-stuff/shuffle_songs.py
           
       - name: Commit changes
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add songs.js
+          git add music-stuff/songs.js
           git diff --quiet && git diff --staged --quiet || (git commit -m "Auto-shuffle songs" && git push) 


### PR DESCRIPTION
## Summary
- run the shuffle script from the music-stuff folder
- commit shuffled songs file using music-stuff path

## Testing
- `python3 -m py_compile customize.py`
- `python3 -m py_compile music-stuff/shuffle_songs.py`


------
https://chatgpt.com/codex/tasks/task_e_68413ea3483083279fe304ebe25cde69