### PR TITLE
Change pink to baby blue on bg site

### DIFF
--- a/bg/style/bundle.css
+++ b/bg/style/bundle.css
@@ -786,12 +786,12 @@ a:active {
   text-indent: 0.25em;
 }
 :root {
-  --color-positive: #FF69B4; /* Submit button */
-  --color-negative: #FF1493; /* Incorrect answer */
+  --color-positive: #87CEEB; /* Submit button */
+  --color-negative: #4682B4; /* Incorrect answer */
   --color-fg: #FFFFFF;       /* Font color and accents */
   --color-mg: #333333;       /* Skip button, progress bar, line colour for inactive guesses */
   --color-bg: #000000;       /* Page background colour */
-  --color-line: #FF69B4;     /* Line color for current guess box, top line, and song player lines */
+  --color-line: #87CEEB;     /* Line color for current guess box, top line, and song player lines */
   --color-highlight: #4A90E2; /* Blue highlight for boy group version */
 }
 @media (min-width: 640px) {


### PR DESCRIPTION
## What’s in this PR?
- [ ] New songs added to `music-stuff/songs.js`
- [ ] Songs moved to `music-stuff/previous_songs.js`
- [x] Docs/other

## Checklist
- [ ] Each entry has both `url` and `answer`
- [ ] If `answer` starts with a number, it has a leading space
- [ ] I ran `python music-stuff/tools/validate_songs.py` locally (optional)
- [ ] No duplicate URLs or answers

## Notes for reviewers
This PR changes pink color values to baby blue shades in the `/bg` site's `bundle.css` as requested by the user.

Specifically:
- `--color-positive` (Submit button) changed from `#FF69B4` to `#87CEEB` (sky blue).
- `--color-negative` (Incorrect answer) changed from `#FF1493` to `#4682B4` (steel blue) for improved contrast.
- `--color-line` (various lines) changed from `#FF69B4` to `#87CEEB` (sky blue).

---
<a href="https://cursor.com/background-agent?bcId=bc-c3f58d95-57b7-44e2-aaf7-088e9287d681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c3f58d95-57b7-44e2-aaf7-088e9287d681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

