### PR TITLE
Redirect boy group song results to kpop.alw.lol

### DIFF
--- a/bg/main.js
+++ b/bg/main.js
@@ -4659,7 +4659,7 @@ var app = (function () {
                 ? (t += "⬛️")
                 : (t += "🟥")
               : (t += "⬜️");
-          let o = e + "\n\n" + t + "\n\n" + "https://kpop.alw.lol/";
+          let o = e + "\n\n" + t + "\n\n" + "https://kpop.alw.lol/bg/";
           if (
             !navigator.share ||
             !/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(


### PR DESCRIPTION
## What’s in this PR?
- [ ] New songs added to `music-stuff/songs.js`
- [ ] Songs moved to `music-stuff/previous_songs.js`
- [x] Docs/other

## Checklist
- [ ] Each entry has both `url` and `answer`
- [ ] If `answer` starts with a number, it has a leading space
- [ ] I ran `python music-stuff/tools/validate_songs.py` locally (optional)
- [ ] No duplicate URLs or answers
*None of the above apply to this PR.*

## Notes for reviewers
This PR fixes the sharing functionality for the boy group (BG) version of the K-pop Heardle game. Previously, sharing results from the BG version would generate a link to the main (girl group) version (`https://kpop.alw.lol/`). This change updates the sharing URL in `bg/main.js` to correctly point to `https://kpop.alw.lol/bg/`, ensuring that shared links from the boy group game lead to the boy group game.

---
<a href="https://cursor.com/background-agent?bcId=bc-cb66fe9f-4a80-478a-ae1e-a88755f6e6a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cb66fe9f-4a80-478a-ae1e-a88755f6e6a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

