### PR TITLE
Remove glitch.me references

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Remixed and extended from the original K-Pop GG Heardle (which ran out of songs)
 
 This is a spin-off of the original [Heardle](https://www.heardle.app/) but for K-Pop Girl Group songs. Each song is randomly chosen from soundclud. I do not own any rights to the songs used in this game. All copyright goes to the relevant parties.
 
-The code for this project is remixed from the [ZAYN Heardle](https://zayn-heardle.glitch.me/) (by [@eggtartemily](https://twitter.com/eggtartemily)) and [Taylor Swift Heardle](https://taylor-swift-heardle.glitch.me/) projects.
+The code for this project is remixed from the ZAYN Heardle (by [@eggtartemily](https://twitter.com/eggtartemily)) and Taylor Swift Heardle projects.
 
 If you have any questions, you can contact me at [alw.lol](https://alw.lol). This project was updated at the request of Dilara.
 
@@ -56,7 +56,7 @@ If you prefer to customize manually, follow these steps:
 4. In the `index.html` file, there is a long link to a photo. Replace every instance of this link with a URL to a photo of your choice.
 5. In the `index.html` file, **remove the Google Analytics tag** at the bottom. You can replace it with your own if you want to track your site usage ([instructions here](https://support.google.com/analytics/answer/9306384?hl=en)) but it's optional.
 6. Songs and answers are defined in the `songs.js` file. The songs should go in the order you want the game to go. You can manually enter the songs or if you know how to, you can write a separate script to randomize the tracks and then just copy and paste. **Note: These tracks have to follow the format `Artist - Track Title` for it to display correctly in the SoundCloud widget.**
-7. In the `main.js` file, search for every instance of 'K-Pop Girl Group'. These will include the text for the info tab, support tab, game link, game messages, etc. Replace these with your artist and customize the text to your liking. **Important:** Change the game link in the clipboard copy to your custom Heardle link. If you forget, users who copy their results will copy the link to this Heardle instead. Search "kpopgg-heardle-round2.glitch.me" if you can't find the line of code.
+7. In the `main.js` file, search for every instance of 'K-Pop Girl Group'. These will include the text for the info tab, support tab, game link, game messages, etc. Replace these with your artist and customize the text to your liking. **Important:** Change the game link in the clipboard copy to your custom Heardle link. If you forget, users who copy their results will copy the link to this Heardle instead.
 8. In the `main.js` file, find where `const Vt` is defined. Below that, there will be a list of game messages that will show depending on how many tries the user guesses the song in. Customize these to your liking.
 9. Also in this section is the variable `startDate`. Theoretically, you would change this to the current date so that the game starts with the first track you listed. However, I noticed that if you do this, it will mess up the SoundCloud player, so I ended up entering a date like a week earlier which was the latest date I could use without messing up the player. It's weird. It seems like a bug in the original Heardle code as well, but I don't know JavaScript well enough to know how to fix this bug. If you do, DM me.
 

--- a/bg/main.js
+++ b/bg/main.js
@@ -3993,7 +3993,7 @@ var app = (function () {
       P(async function () {
         (async function () {
           const e = await fetch(
-            "https://wjsn-heardle.glitch.me/supporters.json"
+            "supporters.json"
           );
           return await e.json();
         })().then((e) => {

--- a/main.js
+++ b/main.js
@@ -3993,7 +3993,7 @@ var app = (function () {
       P(async function () {
         (async function () {
           const e = await fetch(
-            "https://wjsn-heardle.glitch.me/supporters.json"
+            "supporters.json"
           );
           return await e.json();
         })().then((e) => {


### PR DESCRIPTION
## What’s in this PR?
- [ ] New songs added to `music-stuff/songs.js`
- [ ] Songs moved to `music-stuff/previous_songs.js`
- [x] Docs/other

## Checklist
- [ ] Each entry has both `url` and `answer`
- [ ] If `answer` starts with a number, it has a leading space
- [ ] I ran `python music-stuff/tools/validate_songs.py` locally (optional)
- [ ] No duplicate URLs or answers

## Notes for reviewers
Removed all `glitch.me` references from the codebase:
- Updated `main.js` and `bg/main.js` to use a relative path for `supporters.json` instead of an absolute `glitch.me` URL.
- Cleaned up `README.md` by removing `glitch.me` links from project credits and an instruction that referenced a `glitch.me` URL.

---
<a href="https://cursor.com/background-agent?bcId=bc-ad589c4a-3574-44b5-aef7-dc067fce7c67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ad589c4a-3574-44b5-aef7-dc067fce7c67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

