### PR TITLE
Investigate boygroup mobile view issue

### DIFF
--- a/bg/data/songs.js
+++ b/bg/data/songs.js
@@ -14,7 +14,7 @@ let songs = [
   },
   {
     "url": "https://soundcloud.com/kim-xiautaro/seventeen-hot-face-the-sun?in=ap4zljw02nzh/sets/k-pop",
-    "answer": "Adinda Ayu Cahyani - SEVENTEEN (세븐틴) - HOT \"
+    "answer": "Adinda Ayu Cahyani - SEVENTEEN (세븐틴) - HOT"
   },
   {
     "url": "https://soundcloud.com/yeshi-pelden-4156496/mv-pentagon-shine-mp3?in=ap4zljw02nzh/sets/k-pop",


### PR DESCRIPTION
## What’s in this PR?
- [ ] New songs added to `music-stuff/songs.js`
- [ ] Songs moved to `music-stuff/previous_songs.js`
- [x] Docs/other (Fixes a syntax error in `bg/data/songs.js`)

## Checklist
- [x] Each entry has both `url` and `answer`
- [ ] If `answer` starts with a number, it has a leading space
- [ ] I ran `python music-stuff/tools/validate_songs.py` locally (optional)
- [x] No duplicate URLs or answers

## Notes for reviewers
This PR fixes a JavaScript syntax error (an unclosed string) in `bg/data/songs.js` that was causing the "boygroup" page to appear blank on mobile devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-63f5df64-e744-41f4-a155-2a169fe28202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-63f5df64-e744-41f4-a155-2a169fe28202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

